### PR TITLE
Lesson 11: Block Content and Rich Text

### DIFF
--- a/app/(frontend)/posts/[slug]/page.tsx
+++ b/app/(frontend)/posts/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { urlFor } from "@/sanity/lib/image";
+import { PortableText } from "next-sanity";
 
 type PostIndexProps = { params: { slug: string } };
 
@@ -28,6 +29,11 @@ export default async function Page({ params }: PostIndexProps) {
       <h1 className="text-4xl font-bold text-balance dark:text-white">
         {post?.title}
       </h1>
+      {post?.body ? (
+        <article className="prose prose-neutral dark:prose-invert">
+          <PortableText value={post?.body} />
+        </article>
+      ) : null}
       <hr />
       <Link href="/posts" className="dark:text-white">
         &larr; Return to index

--- a/app/(frontend)/posts/[slug]/page.tsx
+++ b/app/(frontend)/posts/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { urlFor } from "@/sanity/lib/image";
 import { PortableText } from "next-sanity";
+import { components } from "@/sanity/portableTextComponents";
 
 type PostIndexProps = { params: { slug: string } };
 
@@ -31,7 +32,7 @@ export default async function Page({ params }: PostIndexProps) {
       </h1>
       {post?.body ? (
         <article className="prose prose-neutral dark:prose-invert">
-          <PortableText value={post?.body} />
+          <PortableText value={post?.body} components={components} />
         </article>
       ) : null}
       <hr />

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.15",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -3933,6 +3934,36 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.15.tgz",
+      "integrity": "sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -9675,6 +9706,13 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9691,6 +9729,13 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/sanity/portableTextComponents.tsx
+++ b/sanity/portableTextComponents.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+import { PortableTextComponents } from "next-sanity";
+import { urlFor } from "@/sanity/lib/image";
+
+export const components: PortableTextComponents = {
+  types: {
+    image: (props) =>
+      props.value ? (
+        <Image
+          className="rounded-lg not-prose w-full h-auto"
+          src={urlFor(props.value)
+            .width(600)
+            .height(400)
+            .quality(80)
+            .auto("format")
+            .url()}
+          alt={props?.value?.alt || ""}
+          width="600"
+          height="400"
+        />
+      ) : null,
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 import animate from "tailwindcss-animate";
+import typography from "@tailwindcss/typography";
 import colors from "tailwindcss/colors";
 
 module.exports = {
@@ -28,6 +29,7 @@ module.exports = {
   },
   plugins: [
     animate,
+    typography,
     // ...
   ],
 };


### PR DESCRIPTION
- [ ] Got a brief introduction to Portable Text within sanity and how it's used inside it's content lake.
- [ ] Installed dependencies for tailwind typography
- [ ] Imported tailwind typography dependencies into tailwind config file
- [ ] Utilized Sanity PortableText component from [@portabletext/react](https://www.npmjs.com/package/@portabletext/react) to render Portable Text blocks into React components
- [ ] Added blocks to sanity editor
- [ ] Update the PortableText component to accept it as a prop
- [ ] 